### PR TITLE
【Fixed】`rails g`コマンドの際にいらないファイルが生成されないように改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,6 @@ module DiveIntoWork
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
     config.generators do |g|
-      # この二行の記述で自動生成しない設定を作成しています。
       g.assets false
       g.helper false
     end


### PR DESCRIPTION
#1

・config/application.rbにasset,helperを自動生成しないように追記

```
#...
  config.generators do |g|
    g.assets  false
    g.helper  false
  end
#...
```
